### PR TITLE
tfswitch: Fix installation on Linux

### DIFF
--- a/Formula/tfswitch.rb
+++ b/Formula/tfswitch.rb
@@ -1,9 +1,15 @@
 class Tfswitch < Formula
   desc "The tfswitch command lets you switch between terraform versions."
   homepage "https://warrensbox.github.io/terraform-switcher"
-  url "https://github.com/warrensbox/terraform-switcher/releases/download/0.8.832/terraform-switcher_0.8.832_darwin_amd64.tar.gz"
+  on_macos do
+    url "https://github.com/warrensbox/terraform-switcher/releases/download/0.8.832/terraform-switcher_0.8.832_darwin_amd64.tar.gz"
+    sha256 "e9ec302dc93f53e5a16d89431d952e1bc251605c0fc529194246cd97442dbd0a"
+  end
+  on_linux do
+    url "https://github.com/warrensbox/terraform-switcher/releases/download/0.8.832/terraform-switcher_0.8.832_linux_amd64.tar.gz"
+    sha256 "8588352b2e98a9e619278985dd986dfc837f5ac5d81310dfffc5e9d9eb7c946d"
+  end
   version "0.8.832"
-  sha256 "e9ec302dc93f53e5a16d89431d952e1bc251605c0fc529194246cd97442dbd0a"
   
   conflicts_with "terraform"
 
@@ -12,7 +18,7 @@ class Tfswitch < Formula
   end
 
   def caveats; <<~EOS
-    Type 'tfswitch' on your command line and choose the terraform version that you want from the dropdown. This command currently only works on MacOs and Linux
+    Type 'tfswitch' on your command line and choose the terraform version that you want from the dropdown. This command currently only works on macOS and Linux.
   EOS
   end
 


### PR DESCRIPTION
- In https://github.com/Homebrew/linuxbrew-core/issues/20949 it was reported that `tfswitch` wasn't executable on Linux: `zsh: permission denied: tfswitch`.
- Homebrew core maintainers usually don't fix issues with third-party taps, but this looks like cool software and I was feeling curious enough to dig into it.
- The `url` of this formula was downloading the Darwin build on both OSes, which caused `Exec format error` when trying to run a macOS binary on Linux.
- This adds `on_macos` and `on_linux` blocks, with individual URLs and SHA256s. This is a little more work for you to keep updated with new versions, but will deliver working software for all your users! :-)
