### PR TITLE
Add support for Linux x86_64

### DIFF
--- a/Formula/tfswitch.rb
+++ b/Formula/tfswitch.rb
@@ -1,11 +1,17 @@
 class Tfswitch < Formula
   desc "The tfswitch command lets you switch between terraform versions."
   homepage "https://warrensbox.github.io/terraform-switcher"
-  url "https://github.com/warrensbox/terraform-switcher/releases/download/0.10.1010/terraform-switcher_0.10.1010_darwin_amd64.tar.gz"
   version "0.10.1010"
-  sha256 "93493513fba4816f3dea938b70b5a360c05c38af22151abcd3a07582dc33fa9c"
   
   conflicts_with "terraform"
+
+  if OS.mac?
+    url "https://github.com/warrensbox/terraform-switcher/releases/download/0.10.1010/terraform-switcher_0.10.1010_darwin_amd64.tar.gz"
+    sha256 "93493513fba4816f3dea938b70b5a360c05c38af22151abcd3a07582dc33fa9c"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/warrensbox/terraform-switcher/releases/download/0.10.1010/terraform-switcher_0.10.1010_linux_amd64.tar.gz"
+    sha256 "cad5c991d0cef09d1e5dfdf0e25e51fb30a2817d8c89dbf4b318bd36e73c7ac1"
+  end
 
   def install
     bin.install "tfswitch"


### PR DESCRIPTION
```
> brew reinstall tfswitch
==> Downloading https://github.com/warrensbox/terraform-switcher/releases/download/0.10.1010/terrafo
==> Downloading from https://github-releases.githubusercontent.com/131640155/f8d45e00-67de-11eb-820f
######################################################################## 100.0%
==> Reinstalling warrensbox/tap/tfswitch
==> Caveats
Type 'tfswitch' on your command line and choose the terraform version that you want from the dropdown. This command currently only works on MacOs and Linux
==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/tfswitch/0.10.1010: 5 files, 11.5MB, built in 2 seconds

> which tfswitch
/home/linuxbrew/.linuxbrew/bin/tfswitch

> tfswitch --version

Version: 0.10.1010
```