### PR TITLE
rm_deprecated_bottle_unneeded

### DIFF
--- a/Formula/health-check.rb
+++ b/Formula/health-check.rb
@@ -6,7 +6,6 @@ class HealthCheck < Formula
   desc "The `health-check` command line tool concurrently checks all target groups's health status"
   homepage "https://warrensbox.github.io/health-check"
   version "0.1.226"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/warrensbox/health-check/releases/download/0.1.226/health-check_0.1.226_darwin_amd64.tar.gz"

--- a/Formula/hubapp.rb
+++ b/Formula/hubapp.rb
@@ -6,7 +6,6 @@ class Hubapp < Formula
   desc "The hubapp command lets you install binary application from github"
   homepage "https://warrensbox.github.io/hubapp"
   version "0.3.21"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/Formula/jscheck.rb
+++ b/Formula/jscheck.rb
@@ -3,7 +3,6 @@ class Jscheck < Formula
   desc "Recursively lint checks json files in you current directory and subdirectories."
   homepage "https://github.com/warrensbox/jscheck"
   version "0.1.102"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/warrensbox/jscheck/releases/download/0.1.102/jscheck_0.1.102_darwin_amd64.tar.gz"

--- a/Formula/tfswitch.rb
+++ b/Formula/tfswitch.rb
@@ -6,7 +6,6 @@ class Tfswitch < Formula
   desc "The tfswitch command lets you switch between terraform versions."
   homepage "https://warrensbox.github.io/terraform-switcher"
   version "0.12.1168"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
hi @warrensbox 

Looks like:
```
bottle :unneeded
```
is deprecated per the warning below on a brew upgrade:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the warrensbox/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/warrensbox/homebrew-tap/Formula/tfswitch.rb:9
```

Also, see these 2 threads:
https://apple.stackexchange.com/questions/429492/warning-calling-bottle-unneeded-is-deprecated-there-is-no-replacement
https://github.com/Homebrew/discussions/discussions/2311